### PR TITLE
Add rabbitmq_policy resource

### DIFF
--- a/providers/policy.rb
+++ b/providers/policy.rb
@@ -1,0 +1,61 @@
+# providers/policy.rb
+#
+# Author: Simple Finance <ops@simple.com>
+# License: Apache License, Version 2.0
+#
+# Copyright 2013 Simple Finance Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Manage policies on RabbitMQ virtualhosts
+
+def initialize(new_resource, run_context)
+  super
+  @manager      = RabbitMQ::Manager.new(node[:rabbitmq])
+  @client       = @manager.client
+  @name         = new_resource.name
+  @vhost        = new_resource.vhost
+  @definition   = new_resource.definition
+  @pattern      = new_resource.pattern
+  @priority     = new_resource.priority
+  @apply_to     = new_resource.apply_to
+end
+
+action :set do
+  if !apply_to_valid?
+    Chef::Log.error("Parameter `apply_to` must be one of 'all', 'queues', or 'exchanges'!")
+    return
+  end
+  attrs = compile_attributes
+  @client.update_policies_of(@vhost, @name, attrs)
+end
+
+action :clear do
+  @client.clear_policies_of(@vhost, @name)
+end
+
+private
+
+def compile_attributes
+  return {
+    'pattern' => @pattern,
+    'definition' => @definition,
+    'priority' => @priority,
+    'apply-to' => @apply_to
+  }
+end
+
+# The `apply-to` parameter can only be a couple things to be valid.
+def apply_to_valid?
+  return ['all', 'exchanges', 'queues'].include?(@apply_to)
+end

--- a/resources/policy.rb
+++ b/resources/policy.rb
@@ -1,0 +1,30 @@
+# resources/policy.rb
+#
+# Author: Simple Finance <ops@simple.com>
+# License: Apache License, Version 2.0
+#
+# Copyright 2013 Simple Finance Technology Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Manage policies on RabbitMQ virtualhosts
+
+actions(:set, :clear)
+default_action(:set)
+
+attribute(:name,       kind_of: String, name_attribute: true)
+attribute(:vhost,      kind_of: String, required: true)
+attribute(:definition, kind_of: Hash,   required: true)
+attribute(:pattern,    kind_of: String, default: '.*')
+attribute(:apply_to,   kind_of: String, default: 'all')
+attribute(:priority,   kind_of: Fixnum, default: 0)


### PR DESCRIPTION
Adds a `rabbitmq_policy` resource which includes a bunch of parameters or whatever. I'll add a README update in a sec.

Resolves https://github.com/jakedavis/chef-rabbitmq/issues/11
