### PR TITLE
Use the cookie

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -79,7 +79,7 @@ action :install do
   # The process for changing the Erlang cookie is to stop the Erlang node,
   # render out the new cookie, start the Erlang node, then reset the RabbitMQ
   # application.
-  if ::File.read('/var/lib/rabbitmq/.erlang.cookie') != @cookie_str
+  if !@cookie_str.nil? && ::File.read('/var/lib/rabbitmq/.erlang.cookie') != @cookie_str
     @service.provider(Chef::Provider::Service::Init)
     @service.run_action(:stop)
 


### PR DESCRIPTION
This was a horrible bug that myself and @tomwans found yesterday while deploying. There were a few mistakes, such as rendering the wrong file (ugh), and not doing the correct commands to change the cookie on a live node, but what we have here works (I tested it after all).

I also took the liberty of cleaning up a bunch of stuff that was no longer needed. This provider had gotten pretty beefy in a past life, and certain things like the reset command really don't need to be a separate method given they're used once. There was also a method which has literally nothing to do with this resource.

Will bump to 1.4.0 upon merge.
