### PR TITLE
Guard cookie logic better

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -153,6 +153,6 @@ def cookie_should_be_rendered?
   if @cookie_str.nil?
     return false
   else
-    return ::File.exists?(cookie_path) || ::File.read(cookie_path) != @cookie_str
+    return !::File.exists?(cookie_path) || ::File.read(cookie_path) != @cookie_str
   end
 end


### PR DESCRIPTION
This ensures the cookie exists on disk before attempting to read it. If the
cookie string is nil, we definitely want to render the cookie no matter what,
so the other condition is one of either the cookie not existing, or the cookies
not being equal.
