### PR TITLE
Just don't worry if the gems were updated

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -45,7 +45,6 @@ action :install do
     gem_resource = Chef::Resource::ChefGem.new(gem, @run_context)
     gem_resource.version(version)
     gem_resource.run_action(:install)
-
   end
 
   @source_pkg.source("https://www.rabbitmq.com/releases/rabbitmq-server/v#{@version}/rabbitmq-server_#{@version}-1_all.deb")
@@ -103,7 +102,6 @@ action :install do
 
   # A bit ugly, but works.
   new_resource.updated_by_last_action(
-    @dep_gems.collect {|g| g.updated_by_last_action? }.any? ||
     @source_pkg.updated_by_last_action? ||
     @installer.updated_by_last_action?  ||
     @service.updated_by_last_action?    ||


### PR DESCRIPTION
This is a bug.

In essence, the gem list is now a Hash, so it has no idea what to do with this and the `update_by_last_action?` fails.